### PR TITLE
fix(database): allow self-signed SSL certificates for Supabase connection

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -17,6 +17,9 @@ const settings = (): DataSourceOptions => {
     logging: true,
     entities: [entitiesPath],
     migrations: [migrationPath],
+    ssl: {
+      rejectUnauthorized: false, // ✅ permite certificados autoassinados
+    },
   };
 };
 


### PR DESCRIPTION
### Summary
This PR fixes the issue with connecting the API to the Supabase PostgreSQL database over IPv4 using the Session Pooler. Previously, the connection was failing due to self-signed SSL certificates.

### Changes
- Added `ssl: { rejectUnauthorized: false }` in TypeORM DataSource configuration.
- Ensures the connection works with Supabase Session Pooler and IPv4 networks.
- Keeps `synchronize: false` to avoid unintended schema changes in production.

### Notes
- The DATABASE_URL environment variable must include `?sslmode=require`.
- No functional changes to the API logic.
