### PR TITLE
Fix/supabase ssl

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -17,6 +17,9 @@ const settings = (): DataSourceOptions => {
     logging: true,
     entities: [entitiesPath],
     migrations: [migrationPath],
+    ssl: {
+      rejectUnauthorized: false, // ✅ permite certificados autoassinados
+    },
   };
 };
 

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -18,9 +18,7 @@ const settings = (): DataSourceOptions => {
     entities: [entitiesPath],
     migrations: [migrationPath],
     extra: {
-      ssl: {
-        rejectUnauthorized: false, // garante que o certificado self-signed será aceito
-      },
+      ssl: true, // força SSL, o Node vai aceitar o certificado do Supabase
     },
   };
 };

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -17,8 +17,10 @@ const settings = (): DataSourceOptions => {
     logging: true,
     entities: [entitiesPath],
     migrations: [migrationPath],
-    ssl: {
-      rejectUnauthorized: false, // ✅ permite certificados autoassinados
+    extra: {
+      ssl: {
+        rejectUnauthorized: false, // garante que o certificado self-signed será aceito
+      },
     },
   };
 };


### PR DESCRIPTION
### Summary
Fixes the PostgreSQL connection issue on Render by enabling SSL for Supabase Session Pooler.

### Changes
- Set `extra.ssl: true` in TypeORM DataSource configuration.
- Removes previous attempt using `rejectUnauthorized: false`.
- Ensures SSL connection works with Supabase IPv4 Pooler.
- Keeps `synchronize: false` to prevent unintended schema changes.
